### PR TITLE
Added a way to update 'topic state' in topic-api-routes.js . If

### DIFF
--- a/routes/topics-api-routes.js
+++ b/routes/topics-api-routes.js
@@ -53,6 +53,8 @@ module.exports = function(app) {
 
   // ----------------------------------------------------------------------------
   // post topics when a topic is created
+  //   make sure that the topic fills in the created_by field, based on the
+  //  the user_id that effectively created the topic
   // ----------------------------------------------------------------------------
   app.post("/api/topics", function(req, res) {
     db.Topics.create(req.body).then(function(topicData) {
@@ -80,6 +82,54 @@ module.exports = function(app) {
     });
   });
 
+  // ----------------------------------------------------------------------------
+  // put update route for changing topic states
+  // ----------------------------------------------------------------------------
+  app.put("/api/topics/:topic_id", function(req, res) {
+    var topicId = parseInt(req.params.topic_id, 10),
+        topicState = req.body.topic_state,
+        userId = parseInt(req.body.user_id, 10),
+        updateObj = {};
+
+    console.log("update topic state, current state: " + topicState);
+    // build the topic id object depending on whether it is an 'open' or
+    // pending object
+    switch (topicState) {
+      case "open":
+        // change state to pending and 'assign user' to topic
+        updateObj = {
+          topic_assigned_to: userId,
+          topic_state: "pending"
+        };
+        break;
+      case "pending":
+        // change state to 'closed', and update topic object in database with
+        // topic video, topic answer text, and topic answer url
+        updateObj = {
+          topic_video: req.body.topic_video,
+          topic_answer: req.body.topic_answer,
+          topic_answer_url: req.body.topic_answer_url,
+          topic_state: "closed"
+        };
+        break;
+      default:
+        break;
+    }
+
+    console.log(JSON.stringify(updateObj));
+
+    db.Topics.update(
+      updateObj,
+      {"where": {"id": topicId}}
+    ).then(function(dbTopic) {
+      if (!dbTopic) res.status(404).end();
+
+      console.log("topic_id " + topicId + " updated successfully.");
+      console.log(dbTopic + " records updated in Topics table");
+
+      res.json(dbTopic);
+    });
+  });
 
   // ============================================================================
   // API DELETE ROUTES FOR TOPICS


### PR DESCRIPTION
a topic is open, the user sends /api/topics/:topic_id an update
request. In the request body there is a 'user_id' -- this will become
the topic's 'topic_assigned_to', and 'topic_state' of open will be
changed to 'pending'. Similarly, if a user has 'solved' the pending
question, the request body contains 'topic_video', 'topic_answer',
'topic_answer_url' and 'topic_state' is changed from 'pending' to
'closed'.